### PR TITLE
Android.mk 文件修改

### DIFF
--- a/libfairygui/Android.mk
+++ b/libfairygui/Android.mk
@@ -37,11 +37,11 @@ Classes/RelationItem.cpp \
 Classes/Relations.cpp \
 Classes/ScrollPane.cpp \
 Classes/Transition.cpp \
+Classes/TranslationHelper.cpp \
 Classes/UIConfig.cpp \
 Classes/UIObjectFactory.cpp \
 Classes/UIPackage.cpp \
 Classes/Window.cpp \
-Classes/display/Actions.cpp \
 Classes/display/BitmapFont.cpp \
 Classes/display/FUIContainer.cpp \
 Classes/display/FUILabel.cpp \
@@ -63,7 +63,7 @@ Classes/gears/GearLook.cpp \
 Classes/gears/GearSize.cpp \
 Classes/gears/GearText.cpp \
 Classes/gears/GearXY.cpp \
-Classes/utils/ByteArray.cpp \
+Classes/utils/ByteBuffer.cpp \
 Classes/utils/ToolSet.cpp \
 Classes/utils/UBBParser.cpp \
 Classes/utils/WeakPtr.cpp \
@@ -71,7 +71,15 @@ Classes/controller_action/ControllerAction.cpp \
 Classes/controller_action/ChangePageAction.cpp \
 Classes/controller_action/PlayTransitionAction.cpp \
 Classes/treeview/TreeView.cpp \
-Classes/treeview/TreeNode.cpp
+Classes/treeview/TreeNode.cpp \
+Classes/tween/EaseManager.cpp \
+Classes/tween/GTween.cpp \
+Classes/tween/GTweener.cpp \
+Classes/tween/TweenManager.cpp \
+Classes/tween/TweenPropType.cpp \
+Classes/tween/TweenValue.cpp
+
+LOCAL_CPP_FEATURES := rtti exceptions
 
 LOCAL_STATIC_LIBRARIES := cocos2dx_static
 


### PR DESCRIPTION
现在的 Android.mk 与代码结构不匹配，有些文件缺失，有些文件已经没有，导致无法通过NDK编译。
我修改了这个文件，并在我本地进行了测试，可以通过编译。