### PR TITLE
make EventContext class inherited from cocos2d::Ref, it is usefull in lua bindings

### DIFF
--- a/libfairygui/Classes/event/EventContext.h
+++ b/libfairygui/Classes/event/EventContext.h
@@ -10,7 +10,7 @@ NS_FGUI_BEGIN
 class GObject;
 class InputProcessor;
 
-class EventContext
+class EventContext : public cocos2d::Ref
 {
 public:
     EventContext();

--- a/libfairygui/Classes/event/InputProcessor.cpp
+++ b/libfairygui/Classes/event/InputProcessor.cpp
@@ -23,6 +23,7 @@ public:
 
     cocos2d::Touch* touch;
     cocos2d::Vec2 pos;
+    cocos2d::Vec2 lastTouchLocation;
     int touchId;
     int clickCount;
     int mouseWheelDelta;
@@ -321,6 +322,7 @@ bool InputProcessor::onTouchBegan(Touch *touch, Event* /*unusedEvent*/)
 
     TouchInfo* ti = getTouch(touch->getID());
     ti->pos = Vec2(pt.x, UIRoot->getHeight() - pt.y);
+	ti->lastTouchLocation = pt;
     ti->button = EventMouse::MouseButton::BUTTON_LEFT;
     ti->touch = touch;
     setBegin(ti, target);
@@ -351,8 +353,12 @@ void InputProcessor::onTouchMoved(Touch *touch, Event* /*unusedEvent*/)
         target = _owner;
 
     TouchInfo* ti = getTouch(touch->getID());
+	if(ti->lastTouchLocation == pt) {
+		return;
+	}
     ti->pos = Vec2(pt.x, UIRoot->getHeight() - pt.y);
     ti->button = EventMouse::MouseButton::BUTTON_LEFT;
+    ti->lastTouchLocation = pt;
     ti->touch = touch;
 
     updateRecentInput(ti, target);
@@ -397,6 +403,7 @@ void InputProcessor::onTouchEnded(Touch *touch, Event* /*unusedEvent*/)
 
     TouchInfo* ti = getTouch(touch->getID());
     ti->pos = Vec2(pt.x, UIRoot->getHeight() - pt.y);
+    ti->lastTouchLocation = pt;
     ti->button = EventMouse::MouseButton::BUTTON_LEFT;
     ti->touch = touch;
     setEnd(ti, target);


### PR DESCRIPTION
把`EventContext` 改为继承自 `cocos2d::Ref`
这样就可以用`stack->pushObject` 将`context`传给lua，然后在lua里调用context的方法，比如`captureTouch`
原来的`EventContext` 由于不是继承自`cocos2d::Ref` ，只能用`stack->pushUserData` 的方式传给lua，这样传进去的context是没法调用自己的方法的。

所以改为`cocos2d::Ref`  子类，希望合并