### PR TITLE
设置字体加粗无效问题

### DIFF
--- a/libfairygui/Classes/display/FUILabel.cpp
+++ b/libfairygui/Classes/display/FUILabel.cpp
@@ -106,7 +106,7 @@ void FUILabel::applyTextFormat()
 
     if (_textFormat->hasEffect(TextFormat::SHADOW))
         enableShadow((Color4B)_textFormat->shadowColor, _textFormat->shadowOffset);
-    else
+    else if(!_textFormat->bold)
         disableEffect(LabelEffect::SHADOW);
 }
 


### PR DESCRIPTION
设置加粗后，在执行else时，调用disableEffect(LabelEffect::SHADOW);又重新设置了_shadowEnabled的值为false。   其实我觉得可以直接不要else，因为cocos的label默认_shadowEnabled就是false的，但不知道当初写else会不会有其他我没看懂的目的，所以做出现在这样的修改，判断不是字体加粗的话仍然继续执行else的代码。