### PR TITLE
优化

### DIFF
--- a/libfairygui/Classes/display/FUIRichText.cpp
+++ b/libfairygui/Classes/display/FUIRichText.cpp
@@ -22,8 +22,7 @@ static const int GUTTER_Y = 2;
 
 static int getPrevWord(const std::string& text, int idx)
 {
-    // start from idx-1
-    for (int i = idx - 1; i >= 0; --i)
+    for (int i = idx + 1; i <= (int)text.size() - 1; ++i)
     {
         if (!std::isalnum(text[i], std::locale()))
             return i;
@@ -627,7 +626,7 @@ int FUIRichText::findSplitPositionForWord(cocos2d::Label* label, const std::stri
         return 0;
     }
 
-    for (int idx = (int)text.size() - 1; idx >= 0; )
+    for (int idx = 0; idx <= (int)text.size() - 1; )
     {
         int newidx = getPrevWord(text, idx);
         if (newidx >= 0)
@@ -635,7 +634,7 @@ int FUIRichText::findSplitPositionForWord(cocos2d::Label* label, const std::stri
             idx = newidx;
             auto leftStr = getSubStringOfUTF8String(text, 0, idx);
             label->setString(leftStr);
-            if (label->getContentSize().width <= originalLeftSpaceWidth)
+            if (label->getContentSize().width >= originalLeftSpaceWidth)
                 return idx;
         }
         else


### PR DESCRIPTION
把倒序遍历的逻辑改成顺序遍历。   当富文本一行字数好多，且不换行的时候，倒序遍历需耗时10秒、100秒、千秒，简直可以说这富文本不可用了。【text.size()很大很大，从text.size()倒序遍历回前面直到找到第一行换行处………………】， 改成顺序遍历，完全不卡。 这里必须改，不然富文本就废了…………

不知道这样改是否有问题，麻烦谷主大大看看。