### PR TITLE
fix wrong display after cocos2d-x-3.17.2

### DIFF
--- a/libfairygui/Classes/FairyGUIMacros.h
+++ b/libfairygui/Classes/FairyGUIMacros.h
@@ -1,6 +1,8 @@
 #ifndef __FAIRYGUIMACROS_H__
 #define __FAIRYGUIMACROS_H__
 
+#include "cocos2d.h"
+
 #define NS_FGUI_BEGIN                     namespace fairygui {
 #define NS_FGUI_END                       }
 #define USING_NS_FGUI                     using namespace fairygui
@@ -8,7 +10,7 @@
 #define CALL_LATER_FUNC(__TYPE__,__FUNC__) \
 void __selector_##__FUNC__(float dt) \
 {\
-    cocos2d::Director::getInstance()->getScheduler()->unschedule(schedule_selector(__TYPE__::__selector_##__FUNC__), this);\
+    cocos2d::Director::getInstance()->getScheduler()->unschedule(CC_SCHEDULE_SELECTOR(__TYPE__::__selector_##__FUNC__), this);\
     __FUNC__(); \
 }\
 void __FUNC__()
@@ -16,6 +18,10 @@ void __FUNC__()
 #define CALL_LATER(__TYPE__,__FUNC__,...) \
 if (!cocos2d::Director::getInstance()->getScheduler()->isScheduled(CC_SCHEDULE_SELECTOR(__TYPE__::__selector_##__FUNC__), this))\
     cocos2d::Director::getInstance()->getScheduler()->schedule(CC_SCHEDULE_SELECTOR(__TYPE__::__selector_##__FUNC__), this, (__VA_ARGS__+0), false)
+
+#ifndef COCOS2DX_VERSION
+#define COCOS2DX_VERSION COCOS2D_VERSION
+#endif
 
 #define CALL_LATER_CANCEL(__TYPE__,__FUNC__) \
 cocos2d::Director::getInstance()->getScheduler()->unschedule(CC_SCHEDULE_SELECTOR(__TYPE__::__selector_##__FUNC__), this)

--- a/libfairygui/Classes/GRoot.cpp
+++ b/libfairygui/Classes/GRoot.cpp
@@ -6,6 +6,10 @@
 NS_FGUI_BEGIN
 USING_NS_CC;
 
+#if COCOS2DX_VERSION < 0x00040000
+using namespace cocos2d::experimental;
+#endif
+
 GRoot* GRoot::_inst = nullptr;
 bool GRoot::_soundEnabled = true;
 float GRoot::_soundVolumeScale = 1.0f;
@@ -463,7 +467,7 @@ void GRoot::playSound(const std::string& url, float volumnScale)
 
     PackageItem* pi = UIPackage::getItemByURL(url);
     if (pi)
-        experimental::AudioEngine::play2d(pi->file, false, _soundVolumeScale * volumnScale);
+        AudioEngine::play2d(pi->file, false, _soundVolumeScale * volumnScale);
 }
 
 void GRoot::setSoundEnabled(bool value)

--- a/libfairygui/Classes/UIPackage.cpp
+++ b/libfairygui/Classes/UIPackage.cpp
@@ -673,7 +673,12 @@ void UIPackage::loadImage(PackageItem* item)
     }
     if (item->scaleByTile)
     {
+#if COCOS2DX_VERSION >= 0x00040000
+        Texture2D::TexParams tp(backend::SamplerFilter::LINEAR, backend::SamplerFilter::LINEAR,
+            backend::SamplerAddressMode::REPEAT, backend::SamplerAddressMode::REPEAT);
+#else
         Texture2D::TexParams tp = {GL_LINEAR, GL_LINEAR, GL_REPEAT, GL_REPEAT};
+#endif
         item->spriteFrame->getTexture()->setTexParameters(tp);
     }
 }

--- a/libfairygui/Classes/UIPackage.cpp
+++ b/libfairygui/Classes/UIPackage.cpp
@@ -588,17 +588,23 @@ void* UIPackage::getItemAsset(PackageItem* item)
 void UIPackage::loadAtlas(PackageItem* item)
 {
     Image* image = new Image();
+#if COCOS2D_VERSION < 0x00031703
     Image::setPNGPremultipliedAlphaEnabled(false);
+#endif
     if (!image->initWithImageFile(item->file))
     {
         item->texture = _emptyTexture;
         _emptyTexture->retain();
         delete image;
+#if COCOS2D_VERSION < 0x00031703
         Image::setPNGPremultipliedAlphaEnabled(true);
+#endif
         CCLOGWARN("FairyGUI: texture '%s' not found in %s", item->file.c_str(), _name.c_str());
         return;
     }
+#if COCOS2D_VERSION < 0x00031703
     Image::setPNGPremultipliedAlphaEnabled(true);
+#endif
 
     Texture2D* tex = new Texture2D();
     tex->initWithImage(image);

--- a/libfairygui/Classes/display/FUIContainer.cpp
+++ b/libfairygui/Classes/display/FUIContainer.cpp
@@ -6,6 +6,7 @@
 NS_FGUI_BEGIN
 USING_NS_CC;
 
+#if COCOS2DX_VERSION < 0x00040000
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_MAC || CC_TARGET_PLATFORM == CC_PLATFORM_WIN32 || CC_TARGET_PLATFORM == CC_PLATFORM_LINUX)
 #define CC_CLIPPING_NODE_OPENGLES 0
 #else
@@ -23,6 +24,7 @@ static void setProgram(Node *n, GLProgram *p)
     }
 }
 #endif
+#endif // COCOS2DX_VERSION < 0x00040000
 
 RectClippingSupport::RectClippingSupport() :
     _clippingEnabled(false),
@@ -151,7 +153,11 @@ void FUIContainer::setStencil(cocos2d::Node * stencil)
     }
 
     if (_stencilClippingSupport->_stencil != nullptr)
+#if COCOS2DX_VERSION >= 0x00040000
+        _stencilClippingSupport->_originStencilProgram = _stencilClippingSupport->_stencil->getProgramState();
+#else
         _stencilClippingSupport->_originStencilProgram = _stencilClippingSupport->_stencil->getGLProgram();
+#endif
 }
 
 GLfloat FUIContainer::getAlphaThreshold() const
@@ -167,6 +173,13 @@ void FUIContainer::setAlphaThreshold(GLfloat alphaThreshold)
     if (_stencilClippingSupport == nullptr)
         _stencilClippingSupport = new StencilClippingSupport();
 
+#if COCOS2DX_VERSION >= 0x00040000
+    if (alphaThreshold == 1 && alphaThreshold != _stencilClippingSupport->_stencilStateManager->getAlphaThreshold()) {
+        if (_stencilClippingSupport->_stencil) {
+            restoreAllProgramStates();
+        }
+    }
+#else
 #if CC_CLIPPING_NODE_OPENGLES
     if (alphaThreshold == 1 && alphaThreshold != _stencilClippingSupport->_stencilStateManager->getAlphaThreshold())
     {
@@ -174,6 +187,7 @@ void FUIContainer::setAlphaThreshold(GLfloat alphaThreshold)
         if (_stencilClippingSupport->_stencil)
             setProgram(_stencilClippingSupport->_stencil, _stencilClippingSupport->_originStencilProgram);
     }
+#endif
 #endif
 
     _stencilClippingSupport->_stencilStateManager->setAlphaThreshold(alphaThreshold);
@@ -279,6 +293,29 @@ void FUIContainer::setContentSize(const Size & contentSize)
         _rectClippingSupport->_clippingRectDirty = true;
 }
 
+#if COCOS2DX_VERSION >= 0x00040000
+void FUIContainer::setProgramStateRecursively(Node* node, backend::ProgramState* programState)
+{
+    _originalStencilProgramState[node] = node->getProgramState();
+    node->setProgramState(programState);
+
+    auto& children = node->getChildren();
+    for (const auto &child : children) {
+        setProgramStateRecursively(child, programState);
+    }
+}
+
+void FUIContainer::restoreAllProgramStates()
+{
+    for (auto item : _originalStencilProgramState)
+    {
+        auto node = item.first;
+        auto programState = item.second;
+        node->setProgramState(programState);
+    }
+}
+#endif
+
 void FUIContainer::onBeforeVisitScissor()
 {
     auto glview = Director::getInstance()->getOpenGLView();
@@ -286,7 +323,11 @@ void FUIContainer::onBeforeVisitScissor()
     Rect clippingRect = getClippingRect();
     if (false == _rectClippingSupport->_scissorOldState)
     {
+#if COCOS2DX_VERSION >= 0x00040000
+        Director::getInstance()->getRenderer()->setScissorTest(true);
+#else
         glEnable(GL_SCISSOR_TEST);
+#endif
     }
     else
     {
@@ -313,7 +354,11 @@ void FUIContainer::onAfterVisitScissor()
     else
     {
         // revert scissor test
+#if COCOS2DX_VERSION >= 0x00040000
+        Director::getInstance()->getRenderer()->setScissorTest(false);
+#else
         glDisable(GL_SCISSOR_TEST);
+#endif
     }
 }
 
@@ -355,13 +400,25 @@ void FUIContainer::visit(cocos2d::Renderer * renderer, const cocos2d::Mat4 & par
 
         renderer->pushGroup(_stencilClippingSupport->_groupCommand.getRenderQueueID());
 
+#if COCOS2DX_VERSION >= 0x00040000
+        _stencilClippingSupport->_stencilStateManager->onBeforeVisit(_globalZOrder);
+#else
         _stencilClippingSupport->_beforeVisitCmd.init(_globalZOrder);
         _stencilClippingSupport->_beforeVisitCmd.func = CC_CALLBACK_0(StencilStateManager::onBeforeVisit, _stencilClippingSupport->_stencilStateManager);
         renderer->addCommand(&_stencilClippingSupport->_beforeVisitCmd);
+#endif
 
         auto alphaThreshold = this->getAlphaThreshold();
         if (alphaThreshold < 1)
         {
+#if COCOS2DX_VERSION >= 0x00040000
+            auto* program = backend::Program::getBuiltinProgram(backend::ProgramType::POSITION_TEXTURE_COLOR_ALPHA_TEST);
+            auto programState = new (std::nothrow) backend::ProgramState(program);
+            auto alphaLocation = programState->getUniformLocation("u_alpha_value");
+            programState->setUniform(alphaLocation, &alphaThreshold, sizeof(alphaThreshold));
+            setProgramStateRecursively(_stencilClippingSupport->_stencil, programState);
+            CC_SAFE_RELEASE_NULL(programState);
+#else
 #if CC_CLIPPING_NODE_OPENGLES
             // since glAlphaTest do not exists in OES, use a shader that writes
             // pixel only if greater than an alpha threshold
@@ -373,6 +430,7 @@ void FUIContainer::visit(cocos2d::Renderer * renderer, const cocos2d::Mat4 & par
             // we need to recursively apply this shader to all the nodes in the stencil node
             // FIXME: we should have a way to apply shader to all nodes without having to do this
             setProgram(_stencilClippingSupport->_stencil, program);
+#endif
 #endif
 
         }
@@ -424,6 +482,11 @@ void FUIContainer::visit(cocos2d::Renderer * renderer, const cocos2d::Mat4 & par
         {
             _rectClippingSupport->_clippingRectDirty = true;
         }
+#if COCOS2DX_VERSION >= 0x00040000
+        _rectClippingSupport->_groupCommand.init(_globalZOrder);
+        renderer->addCommand(&_rectClippingSupport->_groupCommand);
+        renderer->pushGroup(_rectClippingSupport->_groupCommand.getRenderQueueID());
+#endif
         _rectClippingSupport->_beforeVisitCmdScissor.init(_globalZOrder);
         _rectClippingSupport->_beforeVisitCmdScissor.func = CC_CALLBACK_0(FUIContainer::onBeforeVisitScissor, this);
         renderer->addCommand(&_rectClippingSupport->_beforeVisitCmdScissor);
@@ -433,6 +496,9 @@ void FUIContainer::visit(cocos2d::Renderer * renderer, const cocos2d::Mat4 & par
         _rectClippingSupport->_afterVisitCmdScissor.init(_globalZOrder);
         _rectClippingSupport->_afterVisitCmdScissor.func = CC_CALLBACK_0(FUIContainer::onAfterVisitScissor, this);
         renderer->addCommand(&_rectClippingSupport->_afterVisitCmdScissor);
+#if COCOS2DX_VERSION >= 0x00040000
+        renderer->popGroup();
+#endif
     }
     else
         Node::visit(renderer, parentTransform, parentFlags);

--- a/libfairygui/Classes/display/FUIContainer.h
+++ b/libfairygui/Classes/display/FUIContainer.h
@@ -20,8 +20,14 @@ public:
     cocos2d::Rect _clippingRect;
     bool _clippingRectDirty;
 
+#if COCOS2DX_VERSION >= 0x00040000
+    cocos2d::GroupCommand _groupCommand;
+    cocos2d::CallbackCommand _beforeVisitCmdScissor;
+    cocos2d::CallbackCommand _afterVisitCmdScissor;
+#else
     cocos2d::CustomCommand _beforeVisitCmdScissor;
     cocos2d::CustomCommand _afterVisitCmdScissor;
+#endif
 };
 
 class StencilClippingSupport
@@ -30,12 +36,19 @@ public:
     StencilClippingSupport();
 
     cocos2d::Node* _stencil;
-    cocos2d::GLProgram* _originStencilProgram;
     cocos2d::StencilStateManager* _stencilStateManager;
     cocos2d::GroupCommand _groupCommand;
+#if COCOS2DX_VERSION >= 0x00040000
+    cocos2d::backend::ProgramState* _originStencilProgram;
+    cocos2d::CallbackCommand _beforeVisitCmd;
+    cocos2d::CallbackCommand _afterDrawStencilCmd;
+    cocos2d::CallbackCommand _afterVisitCmd;
+#else
+    cocos2d::GLProgram* _originStencilProgram;
     cocos2d::CustomCommand _beforeVisitCmd;
     cocos2d::CustomCommand _afterDrawStencilCmd;
     cocos2d::CustomCommand _afterVisitCmd;
+#endif
 };
 
 class FUIContainer : public cocos2d::Node
@@ -75,6 +88,13 @@ private:
 
     RectClippingSupport* _rectClippingSupport;
     StencilClippingSupport* _stencilClippingSupport;
+    
+#if COCOS2DX_VERSION >= 0x00040000
+    void setProgramStateRecursively(Node* node, cocos2d::backend::ProgramState* programState);
+    void restoreAllProgramStates();
+    
+    std::unordered_map<Node*, cocos2d::backend::ProgramState*> _originalStencilProgramState;
+#endif
 };
 
 //internal use

--- a/libfairygui/Classes/display/FUISprite.h
+++ b/libfairygui/Classes/display/FUISprite.h
@@ -38,10 +38,8 @@ public:
 protected:
     virtual void draw(cocos2d::Renderer *renderer, const cocos2d::Mat4 &transform, uint32_t flags) override;
 
-    void onDraw(const cocos2d::Mat4 &transform, uint32_t flags);
-
     cocos2d::Tex2F textureCoordFromAlphaPoint(cocos2d::Vec2 alpha);
-    cocos2d::Vec2 vertexFromAlphaPoint(cocos2d::Vec2 alpha);
+    cocos2d::Vec3 vertexFromAlphaPoint(cocos2d::Vec2 alpha);
     void updateBar(void);
     void updateRadial(void);
     virtual void updateColor(void) override;
@@ -55,10 +53,10 @@ private:
     float _fillAmount;
     bool _fillClockwise;
     bool _scaleByTile;
-    cocos2d::CustomCommand _customCommand;
     int _vertexDataCount;
-    cocos2d::V2F_C4B_T2F *_vertexData;
-    cocos2d::GLProgramState *_fillGlProgramState;
+    cocos2d::TrianglesCommand::Triangles _fillTriangles;
+    cocos2d::V3F_C4B_T2F *_vertexData;
+    unsigned short *_vertexIndex;
     
     static cocos2d::Texture2D* _empty;
 };

--- a/libfairygui/Classes/event/HitTest.h
+++ b/libfairygui/Classes/event/HitTest.h
@@ -12,6 +12,7 @@ class ByteBuffer;
 class IHitTest
 {
 public:
+    virtual ~IHitTest() {};
     virtual bool hitTest(GComponent* obj, const cocos2d::Vec2& localPoint)
     {
         return true;

--- a/libfairygui/Classes/tween/TweenManager.cpp
+++ b/libfairygui/Classes/tween/TweenManager.cpp
@@ -10,12 +10,23 @@ int TweenManager::_totalActiveTweens = 0;
 int TweenManager::_arrayLength = 0;
 bool TweenManager::_inited = false;
 
+static std::string UPDATE_KEY = "__TweenEngine__update__";
+
 class TweenEngine
 {
 public:
     void update(float dt)
     {
         TweenManager::update(dt);
+    }
+    
+    static void activate(TweenEngine *engine)
+    {
+        auto scheduler = cocos2d::Director::getInstance()->getScheduler();
+        if (!scheduler->isScheduled(UPDATE_KEY, engine)) {
+            scheduler->schedule([](float dt){}, engine, FLT_MAX, false, UPDATE_KEY);
+            scheduler->scheduleUpdate(engine, INT_MIN + 10, false);
+        }
     }
 };
 static TweenEngine tweenEngine;
@@ -24,6 +35,8 @@ GTweener* TweenManager::createTween()
 {
     if (!_inited)
         init();
+    
+    TweenEngine::activate(&tweenEngine);
 
     GTweener* tweener;
     int cnt = (int)_tweenerPool.size();
@@ -172,8 +185,6 @@ void TweenManager::init()
 
     _arrayLength = 30;
     _activeTweens = new GTweener*[_arrayLength];
-
-    cocos2d::Director::getInstance()->getScheduler()->scheduleUpdate(&tweenEngine, INT_MIN + 10, false);
 }
 
 NS_FGUI_END

--- a/libfairygui/Classes/utils/ByteBuffer.cpp
+++ b/libfairygui/Classes/utils/ByteBuffer.cpp
@@ -159,10 +159,17 @@ void ByteBuffer::writeS(const std::string& value)
 cocos2d::Color4B ByteBuffer::readColor()
 {
     int startIndex = _offset + _position;
+#if COCOS2DX_VERSION >= 0x00040000
+    uint8_t r = _buffer[startIndex];
+    uint8_t g = _buffer[startIndex + 1];
+    uint8_t b = _buffer[startIndex + 2];
+    uint8_t a = _buffer[startIndex + 3];
+#else
     GLubyte r = _buffer[startIndex];
     GLubyte g = _buffer[startIndex + 1];
     GLubyte b = _buffer[startIndex + 2];
     GLubyte a = _buffer[startIndex + 3];
+#endif
     _position += 4;
 
     return cocos2d::Color4B(r, g, b, a);


### PR DESCRIPTION
After cocos2d-x-3.17.2 release, the engine change some logic about premultipliedAlpha, if set false, the result of this image is 'hasAlphaPremultipledAlpha() == true'. I think next version code must be great than 0x00031702