### PR TITLE
fix wrong display after cocos2d-x-3.17.2

### DIFF
--- a/libfairygui/Classes/UIPackage.cpp
+++ b/libfairygui/Classes/UIPackage.cpp
@@ -588,17 +588,23 @@ void* UIPackage::getItemAsset(PackageItem* item)
 void UIPackage::loadAtlas(PackageItem* item)
 {
     Image* image = new Image();
+#if COCOS2D_VERSION <= 0x00031702
     Image::setPNGPremultipliedAlphaEnabled(false);
+#endif
     if (!image->initWithImageFile(item->file))
     {
         item->texture = _emptyTexture;
         _emptyTexture->retain();
         delete image;
+#if COCOS2D_VERSION <= 0x00031702
         Image::setPNGPremultipliedAlphaEnabled(true);
+#endif
         CCLOGWARN("FairyGUI: texture '%s' not found in %s", item->file.c_str(), _name.c_str());
         return;
     }
+#if COCOS2D_VERSION <= 0x00031702
     Image::setPNGPremultipliedAlphaEnabled(true);
+#endif
 
     Texture2D* tex = new Texture2D();
     tex->initWithImage(image);


### PR DESCRIPTION
After cocos2d-x-3.17.2 release, the engine change some logic about premultipliedAlpha, if set false, the result of this image is 'hasAlphaPremultipledAlpha() == true'. I think next version code must be great than 0x00031702