### PR TITLE
cocos2dx version macro renamed to COCOS2D_VERSION

### DIFF
--- a/libfairygui/Classes/FairyGUIMacros.h
+++ b/libfairygui/Classes/FairyGUIMacros.h
@@ -19,10 +19,6 @@ void __FUNC__()
 if (!cocos2d::Director::getInstance()->getScheduler()->isScheduled(CC_SCHEDULE_SELECTOR(__TYPE__::__selector_##__FUNC__), this))\
     cocos2d::Director::getInstance()->getScheduler()->schedule(CC_SCHEDULE_SELECTOR(__TYPE__::__selector_##__FUNC__), this, (__VA_ARGS__+0), false)
 
-#ifndef COCOS2DX_VERSION
-#define COCOS2DX_VERSION COCOS2D_VERSION
-#endif
-
 #define CALL_LATER_CANCEL(__TYPE__,__FUNC__) \
 cocos2d::Director::getInstance()->getScheduler()->unschedule(CC_SCHEDULE_SELECTOR(__TYPE__::__selector_##__FUNC__), this)
 

--- a/libfairygui/Classes/GRoot.cpp
+++ b/libfairygui/Classes/GRoot.cpp
@@ -6,7 +6,7 @@
 NS_FGUI_BEGIN
 USING_NS_CC;
 
-#if COCOS2DX_VERSION < 0x00040000
+#if COCOS2D_VERSION < 0x00040000
 using namespace cocos2d::experimental;
 #endif
 

--- a/libfairygui/Classes/UIPackage.cpp
+++ b/libfairygui/Classes/UIPackage.cpp
@@ -673,7 +673,7 @@ void UIPackage::loadImage(PackageItem* item)
     }
     if (item->scaleByTile)
     {
-#if COCOS2DX_VERSION >= 0x00040000
+#if COCOS2D_VERSION >= 0x00040000
         Texture2D::TexParams tp(backend::SamplerFilter::LINEAR, backend::SamplerFilter::LINEAR,
             backend::SamplerAddressMode::REPEAT, backend::SamplerAddressMode::REPEAT);
 #else

--- a/libfairygui/Classes/display/FUIContainer.cpp
+++ b/libfairygui/Classes/display/FUIContainer.cpp
@@ -6,7 +6,7 @@
 NS_FGUI_BEGIN
 USING_NS_CC;
 
-#if COCOS2DX_VERSION < 0x00040000
+#if COCOS2D_VERSION < 0x00040000
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_MAC || CC_TARGET_PLATFORM == CC_PLATFORM_WIN32 || CC_TARGET_PLATFORM == CC_PLATFORM_LINUX)
 #define CC_CLIPPING_NODE_OPENGLES 0
 #else
@@ -24,7 +24,7 @@ static void setProgram(Node *n, GLProgram *p)
     }
 }
 #endif
-#endif // COCOS2DX_VERSION < 0x00040000
+#endif // COCOS2D_VERSION < 0x00040000
 
 RectClippingSupport::RectClippingSupport() :
     _clippingEnabled(false),
@@ -153,7 +153,7 @@ void FUIContainer::setStencil(cocos2d::Node * stencil)
     }
 
     if (_stencilClippingSupport->_stencil != nullptr)
-#if COCOS2DX_VERSION >= 0x00040000
+#if COCOS2D_VERSION >= 0x00040000
         _stencilClippingSupport->_originStencilProgram = _stencilClippingSupport->_stencil->getProgramState();
 #else
         _stencilClippingSupport->_originStencilProgram = _stencilClippingSupport->_stencil->getGLProgram();
@@ -173,7 +173,7 @@ void FUIContainer::setAlphaThreshold(float alphaThreshold)
     if (_stencilClippingSupport == nullptr)
         _stencilClippingSupport = new StencilClippingSupport();
 
-#if COCOS2DX_VERSION >= 0x00040000
+#if COCOS2D_VERSION >= 0x00040000
     if (alphaThreshold == 1 && alphaThreshold != _stencilClippingSupport->_stencilStateManager->getAlphaThreshold()) {
         if (_stencilClippingSupport->_stencil) {
             restoreAllProgramStates();
@@ -293,7 +293,7 @@ void FUIContainer::setContentSize(const Size & contentSize)
         _rectClippingSupport->_clippingRectDirty = true;
 }
 
-#if COCOS2DX_VERSION >= 0x00040000
+#if COCOS2D_VERSION >= 0x00040000
 void FUIContainer::setProgramStateRecursively(Node* node, backend::ProgramState* programState)
 {
     _originalStencilProgramState[node] = node->getProgramState();
@@ -323,7 +323,7 @@ void FUIContainer::onBeforeVisitScissor()
     Rect clippingRect = getClippingRect();
     if (false == _rectClippingSupport->_scissorOldState)
     {
-#if COCOS2DX_VERSION >= 0x00040000
+#if COCOS2D_VERSION >= 0x00040000
         Director::getInstance()->getRenderer()->setScissorTest(true);
 #else
         glEnable(GL_SCISSOR_TEST);
@@ -354,7 +354,7 @@ void FUIContainer::onAfterVisitScissor()
     else
     {
         // revert scissor test
-#if COCOS2DX_VERSION >= 0x00040000
+#if COCOS2D_VERSION >= 0x00040000
         Director::getInstance()->getRenderer()->setScissorTest(false);
 #else
         glDisable(GL_SCISSOR_TEST);
@@ -400,7 +400,7 @@ void FUIContainer::visit(cocos2d::Renderer * renderer, const cocos2d::Mat4 & par
 
         renderer->pushGroup(_stencilClippingSupport->_groupCommand.getRenderQueueID());
 
-#if COCOS2DX_VERSION >= 0x00040000
+#if COCOS2D_VERSION >= 0x00040000
         _stencilClippingSupport->_stencilStateManager->onBeforeVisit(_globalZOrder);
 #else
         _stencilClippingSupport->_beforeVisitCmd.init(_globalZOrder);
@@ -411,7 +411,7 @@ void FUIContainer::visit(cocos2d::Renderer * renderer, const cocos2d::Mat4 & par
         auto alphaThreshold = this->getAlphaThreshold();
         if (alphaThreshold < 1)
         {
-#if COCOS2DX_VERSION >= 0x00040000
+#if COCOS2D_VERSION >= 0x00040000
             auto* program = backend::Program::getBuiltinProgram(backend::ProgramType::POSITION_TEXTURE_COLOR_ALPHA_TEST);
             auto programState = new (std::nothrow) backend::ProgramState(program);
             auto alphaLocation = programState->getUniformLocation("u_alpha_value");
@@ -482,7 +482,7 @@ void FUIContainer::visit(cocos2d::Renderer * renderer, const cocos2d::Mat4 & par
         {
             _rectClippingSupport->_clippingRectDirty = true;
         }
-#if COCOS2DX_VERSION >= 0x00040000
+#if COCOS2D_VERSION >= 0x00040000
         _rectClippingSupport->_groupCommand.init(_globalZOrder);
         renderer->addCommand(&_rectClippingSupport->_groupCommand);
         renderer->pushGroup(_rectClippingSupport->_groupCommand.getRenderQueueID());
@@ -496,7 +496,7 @@ void FUIContainer::visit(cocos2d::Renderer * renderer, const cocos2d::Mat4 & par
         _rectClippingSupport->_afterVisitCmdScissor.init(_globalZOrder);
         _rectClippingSupport->_afterVisitCmdScissor.func = CC_CALLBACK_0(FUIContainer::onAfterVisitScissor, this);
         renderer->addCommand(&_rectClippingSupport->_afterVisitCmdScissor);
-#if COCOS2DX_VERSION >= 0x00040000
+#if COCOS2D_VERSION >= 0x00040000
         renderer->popGroup();
 #endif
     }

--- a/libfairygui/Classes/display/FUIContainer.h
+++ b/libfairygui/Classes/display/FUIContainer.h
@@ -20,7 +20,7 @@ public:
     cocos2d::Rect _clippingRect;
     bool _clippingRectDirty;
 
-#if COCOS2DX_VERSION >= 0x00040000
+#if COCOS2D_VERSION >= 0x00040000
     cocos2d::GroupCommand _groupCommand;
     cocos2d::CallbackCommand _beforeVisitCmdScissor;
     cocos2d::CallbackCommand _afterVisitCmdScissor;
@@ -38,7 +38,7 @@ public:
     cocos2d::Node* _stencil;
     cocos2d::StencilStateManager* _stencilStateManager;
     cocos2d::GroupCommand _groupCommand;
-#if COCOS2DX_VERSION >= 0x00040000
+#if COCOS2D_VERSION >= 0x00040000
     cocos2d::backend::ProgramState* _originStencilProgram;
     cocos2d::CallbackCommand _beforeVisitCmd;
     cocos2d::CallbackCommand _afterDrawStencilCmd;
@@ -89,7 +89,7 @@ private:
     RectClippingSupport* _rectClippingSupport;
     StencilClippingSupport* _stencilClippingSupport;
     
-#if COCOS2DX_VERSION >= 0x00040000
+#if COCOS2D_VERSION >= 0x00040000
     void setProgramStateRecursively(Node* node, cocos2d::backend::ProgramState* programState);
     void restoreAllProgramStates();
     

--- a/libfairygui/Classes/display/FUISprite.cpp
+++ b/libfairygui/Classes/display/FUISprite.cpp
@@ -100,7 +100,7 @@ void FUISprite::setScaleByTile(bool value)
 
 void FUISprite::setGrayed(bool value)
 {
-#if COCOS2DX_VERSION >= 0x00040000
+#if COCOS2D_VERSION >= 0x00040000
     auto isETC1 = getTexture() && getTexture()->getAlphaTextureName();
     if (value) {
         Sprite::updateShaders(positionTextureColor_vert, (isETC1)?etc1Gray_frag:grayScale_frag);
@@ -486,7 +486,7 @@ void FUISprite::draw(cocos2d::Renderer* renderer, const cocos2d::Mat4& transform
         Sprite::draw(renderer, transform, flags);
     else
     {
-#if COCOS2DX_VERSION >= 0x00040000
+#if COCOS2D_VERSION >= 0x00040000
         setMVPMatrixUniform();
 #endif
 
@@ -511,7 +511,7 @@ void FUISprite::draw(cocos2d::Renderer* renderer, const cocos2d::Mat4& transform
         {
             _trianglesCommand.init(_globalZOrder,
                                    _texture,
-#if COCOS2DX_VERSION < 0x00040000
+#if COCOS2D_VERSION < 0x00040000
                                    getGLProgramState(),
 #endif
                                    _blendFunc,

--- a/libfairygui/Classes/utils/ByteBuffer.cpp
+++ b/libfairygui/Classes/utils/ByteBuffer.cpp
@@ -159,7 +159,7 @@ void ByteBuffer::writeS(const std::string& value)
 cocos2d::Color4B ByteBuffer::readColor()
 {
     int startIndex = _offset + _position;
-#if COCOS2DX_VERSION >= 0x00040000
+#if COCOS2D_VERSION >= 0x00040000
     uint8_t r = _buffer[startIndex];
     uint8_t g = _buffer[startIndex + 1];
     uint8_t b = _buffer[startIndex + 2];


### PR DESCRIPTION
In v3 or v4, the version macro is COCOS2D_VERSION, there is unnecessary to define another one.