### PR TITLE
improve cooperation with other cocos2dx Node

### DIFF
--- a/libfairygui/Classes/event/InputProcessor.cpp
+++ b/libfairygui/Classes/event/InputProcessor.cpp
@@ -310,6 +310,26 @@ bool InputProcessor::isTouchOnUI()
     return _touchOnUI;
 }
 
+void InputProcessor::disableDefaultTouchEvent()
+{
+    _owner->displayObject()->getEventDispatcher()->removeEventListener(_touchListener);
+}
+
+bool InputProcessor::touchDown(cocos2d::Touch *touch, cocos2d::Event *event)
+{
+    return onTouchBegan(touch, event);
+}
+
+void InputProcessor::touchMove(cocos2d::Touch *touch, cocos2d::Event *event)
+{
+    onTouchMoved(touch, event);
+}
+
+void InputProcessor::touchUp(cocos2d::Touch *touch, cocos2d::Event *event)
+{
+    onTouchEnded(touch, event);
+}
+
 bool InputProcessor::onTouchBegan(Touch *touch, Event* /*unusedEvent*/)
 {
     auto camera = Camera::getVisitingCamera();

--- a/libfairygui/Classes/event/InputProcessor.h
+++ b/libfairygui/Classes/event/InputProcessor.h
@@ -31,7 +31,12 @@ public:
     void simulateClick(GObject* target, int touchId = -1);
 
     void setCaptureCallback(CaptureEventCallback value) { _captureCallback = value; }
-
+    
+    void disableDefaultTouchEvent();
+    bool touchDown(cocos2d::Touch *touch, cocos2d::Event *event);
+    void touchMove(cocos2d::Touch *touch, cocos2d::Event *event);
+    void touchUp(cocos2d::Touch *touch, cocos2d::Event *event);
+    
 private:
     bool onTouchBegan(cocos2d::Touch * touch, cocos2d::Event *);
     void onTouchMoved(cocos2d::Touch * touch, cocos2d::Event *);


### PR DESCRIPTION
When add other node(spine node) to the GObject.displayObject, and this node listen the EventListenerTouchAllAtOnce, because the EventListenerTouchOneByOne is higher priority, so InputProcess will swallow the touches, it cause the node can't receive any TouchEvent. Add these apis, let user have opportunity to control event.