### PR TITLE
fix using percent flag in transition when not using the tween object

### DIFF
--- a/libfairygui/Classes/Transition.cpp
+++ b/libfairygui/Classes/Transition.cpp
@@ -721,7 +721,7 @@ void Transition::updateFromRelations(const std::string& targetId, float dx, floa
             }
             else
             {
-                if(!item->tweenConfig->startValue->b3){
+                if(!((TValue*)item->value)->b3){
                     ((TValue*)item->value)->f1 += dx;
                     ((TValue*)item->value)->f2 += dy;
                 }


### PR DESCRIPTION
It was missing this part to fix the problem when not using the tween in the transition.