### PR TITLE
fix crash when dynamic update 'fillAmount'

### DIFF
--- a/libfairygui/Classes/display/FUISprite.cpp
+++ b/libfairygui/Classes/display/FUISprite.cpp
@@ -346,6 +346,11 @@ void FUISprite::updateRadial(void)
         _vertexIndex = (unsigned short *)malloc(triangleCount * 3 * sizeof(*_vertexIndex));
         CCASSERT(_vertexData, "FUISprite. Not enough memory");
     }
+    else
+    {
+        triangleCount = _vertexDataCount - 2;
+    }
+    
     updateColor();
 
     if (!sameIndexCount)


### PR DESCRIPTION
If dynamic update 'fillAmount', when '_vertexDataCount' no changes, 'triangleCount' is 0, it cause crash.