### PR TITLE
Update HtmlObject.cpp

### DIFF
--- a/libfairygui/Classes/utils/html/HtmlObject.cpp
+++ b/libfairygui/Classes/utils/html/HtmlObject.cpp
@@ -132,8 +132,8 @@ void HtmlObject::createImage()
     _ui = loader;
 
     loader->setSize(width, height);
-    loader->setFill(LoaderFillType::SCALE_FREE);
     loader->setURL(src);
+    loader->setFill(LoaderFillType::SCALE_FREE);
 }
 
 void HtmlObject::createButton()


### PR DESCRIPTION
游戏崩溃，HtmlObject的createImage里获取的GLoader的_contentItem指针未至null