### PR TITLE
fix stencil clipper issue with globalZOrder

### DIFF
--- a/libfairygui/Classes/display/FUIContainer.cpp
+++ b/libfairygui/Classes/display/FUIContainer.cpp
@@ -496,4 +496,14 @@ void FUIContainer::visit(cocos2d::Renderer * renderer, const cocos2d::Mat4 & par
         Node::visit(renderer, parentTransform, parentFlags);
 }
 
+void FUIContainer::setGlobalZOrder(float globalZOrder)
+{
+    Node::setGlobalZOrder(globalZOrder);
+    if (_stencilClippingSupport && _stencilClippingSupport->_stencil)
+    {
+        _stencilClippingSupport->_stencil->setGlobalZOrder(globalZOrder);
+    }
+}
+
+
 NS_FGUI_END

--- a/libfairygui/Classes/display/FUIContainer.h
+++ b/libfairygui/Classes/display/FUIContainer.h
@@ -77,6 +77,7 @@ public:
     void onExit() override;
     void visit(cocos2d::Renderer *renderer, const cocos2d::Mat4 &parentTransform, uint32_t parentFlags) override;
     void setCameraMask(unsigned short mask, bool applyChildren = true) override;
+    void setGlobalZOrder(float globalZOrder) override;
 
     GObject* gOwner;
 private:


### PR DESCRIPTION
I was changing globalzorder of FUIContainers in my tutorials. Currently, if we change globalzorder of a FUIContainer having stencil clipping, clipped node does not get displayed.  This PR fixes the issue. 