### PR TITLE
fixed GButton pressed state issue with global z indexing.

### DIFF
--- a/libfairygui/Classes/GComponent.cpp
+++ b/libfairygui/Classes/GComponent.cpp
@@ -711,6 +711,8 @@ void GComponent::childStateChanged(GObject* child)
             if (_childrenRenderOrder == ChildrenRenderOrder::ASCENT)
             {
                 int index = (int)_children.getIndex(child);
+                const int globalZOrder = _container->getGlobalZOrder();
+                child->_displayObject->setGlobalZOrder(globalZOrder);
                 _container->addChild(child->_displayObject, index);
                 size_t cnt = _children.size();
                 for (size_t i = index + 1; i < cnt; i++)


### PR DESCRIPTION
If Gbutton global z index is changed, pressed state do not appear. This PR will set global z index of pressed. state to same as of button container.  