### PR TITLE
fix children display order error after child removed

### DIFF
--- a/libfairygui/Classes/GComponent.cpp
+++ b/libfairygui/Classes/GComponent.cpp
@@ -742,6 +742,7 @@ void GComponent::childStateChanged(GObject* child)
             {
                 CALL_LATER(GComponent, buildNativeDisplayList);
             }
+            refreshChildrenDisplayOrder();
         }
     }
     else
@@ -1385,6 +1386,23 @@ void GComponent::setup_afterAdd(ByteBuffer* buffer, int beginPos)
             GObject* obj = getChildByPath(target);
             if (obj != nullptr)
                 obj->setProp(propId, Value(value));
+        }
+    }
+}
+
+void GComponent::refreshChildrenDisplayOrder() {
+    if (_childrenRenderOrder == ChildrenRenderOrder::ASCENT)
+    {
+        int count = (int)_children.size();
+        for (int i = 0; i < count; ++i) {
+            _children.at(i)->displayObject()->setLocalZOrder(i);
+        }
+    }
+    else if (_childrenRenderOrder == ChildrenRenderOrder::DESCENT)
+    {
+        int count = (int)_children.size();
+        for (int i = 0; i < count; ++i) {
+            _children.at(i)->displayObject()->setLocalZOrder(count - 1 - i);
         }
     }
 }

--- a/libfairygui/Classes/GComponent.h
+++ b/libfairygui/Classes/GComponent.h
@@ -136,7 +136,8 @@ protected:
 private:
     int getInsertPosForSortingChild(GObject* target);
     int moveChild(GObject* child, int oldIndex, int index);
-
+    void refreshChildrenDisplayOrder();
+    
     CALL_LATER_FUNC(GComponent, doUpdateBounds);
     CALL_LATER_FUNC(GComponent, buildNativeDisplayList);
 


### PR DESCRIPTION
GComponent移除子节点之后，没有重置所有子节点的localzorder，导致之后新加入子节点有可能不位于最上层。